### PR TITLE
Add video player support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "dependencies/all/asio"]
 	path = dependencies/all/asio
 	url = https://github.com/chriskohlhoff/asio.git
+[submodule "dependencies/all/theoraplay"]
+	path = dependencies/all/theoraplay
+	url = https://github.com/icculus/theoraplay.git

--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,8 @@ ifeq ($(STATIC),1)
 	CXXFLAGS += -static
 endif
 
-CXXFLAGS_ALL = `$(PKGCONFIG) --cflags --static sdl2 vorbisfile vorbis`
-LIBS_ALL = `$(PKGCONFIG) --libs --static sdl2 vorbisfile vorbis`
+CXXFLAGS_ALL = `$(PKGCONFIG) --cflags --static sdl2 vorbisfile vorbis theoradec`
+LIBS_ALL = `$(PKGCONFIG) --libs --static sdl2 vorbisfile vorbis theoradec`
 
 CXXFLAGS_ALL += $(CXXFLAGS) \
                -DBASE_PATH='"$(BASE_PATH)"' \
@@ -87,8 +87,8 @@ INCLUDES  += \
     -I./RSDKv4/NativeObjects/ \
     -I./dependencies/all/asio/asio/include/ \
     -I./dependencies/all/stb-image/ \
-    -I./dependencies/all/tinyxml2/
-
+    -I./dependencies/all/tinyxml2/ \
+    -I./dependencies/all/theoraplay/
 
 INCLUDES += $(LIBS)
 
@@ -116,8 +116,10 @@ SOURCES = \
     RSDKv4/String       \
     RSDKv4/Text         \
     RSDKv4/Userdata     \
+    RSDKv4/Video        \
     RSDKv4/main         \
     RSDKv4/NativeObjects/All                \
+    dependencies/all/theoraplay/theoraplay  \
     dependencies/all/tinyxml2/tinyxml2
 
 PKGSUFFIX ?= $(SUFFIX)

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ If you want to transfer your save(s) from the official mobile version(s), the **
 ## Linux
 ### Decompilation
 * To setup your build enviroment and library dependecies, run the following commands:
-  * Ubuntu (Mint, Pop!_OS, etc...): `sudo apt install build-essential git libsdl2-dev libvorbis-dev libogg-dev libglew-dev`
+  * Ubuntu (Mint, Pop!_OS, etc...): `sudo apt install build-essential git libsdl2-dev libvorbis-dev libogg-dev libglew-dev libtheora-dev`
     * If you're using Debian, add `libgbm-dev` and `libdrm-dev`.
-  * Arch Linux: `sudo pacman -S base-devel git sdl2 libvorbis libogg glew`
+  * Arch Linux: `sudo pacman -S base-devel git sdl2 libvorbis libogg glew libtheora`
   * Clone the repo and its other dependencies with the following command: `git clone --recursive https://github.com/Rubberduckycooly/Sonic-1-2-2013-Decompilation.git`
   * Go into the repo you just cloned with `cd Sonic-1-2-2013-Decompilation`.
   * Run `make -j5`.

--- a/RSDKv4/Drawing.hpp
+++ b/RSDKv4/Drawing.hpp
@@ -78,6 +78,7 @@ extern bool mixFiltersOnJekyll;
 extern GLint defaultFramebuffer;
 extern GLuint framebufferHiRes;
 extern GLuint renderbufferHiRes;
+extern GLuint videoBuffer;
 #endif
 
 int InitRenderDevice();

--- a/RSDKv4/NativeObjects/RetroGameLoop.cpp
+++ b/RSDKv4/NativeObjects/RetroGameLoop.cpp
@@ -80,6 +80,12 @@ void RetroGameLoop_Main(void *objPtr)
             RestoreNativeObjects();
             break;
 
+        case ENGINE_VIDEOWAIT:
+            if (ProcessVideo() == 1) {
+                Engine.gameMode = ENGINE_MAINGAME;
+            }
+            break;
+
 #if !RETRO_USE_ORIGINAL_CODE && RETRO_USE_NETWORKING
         case ENGINE_CONNECT2PVS: {
             CREATE_ENTITY(MultiplayerScreen)->bg = CREATE_ENTITY(MenuBG);

--- a/RSDKv4/RSDKv4.vcxproj
+++ b/RSDKv4/RSDKv4.vcxproj
@@ -112,15 +112,15 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;USE_SW_REN;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)RSDKv4/;$(SolutionDir)RSDKv4/NativeObjects/;$(SolutionDir)dependencies/all/asio/asio/include/;$(SolutionDir)dependencies/all/stb-image/;$(SolutionDir)dependencies/all/tinyxml2/;$(SolutionDir)dependencies/windows/SDL2/include/;$(SolutionDir)dependencies/windows/libogg/include/;$(SolutionDir)dependencies/windows/libvorbis/include/;$(SolutionDir)dependencies/windows/glew/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)RSDKv4/;$(SolutionDir)RSDKv4/NativeObjects/;$(SolutionDir)dependencies/all/asio/asio/include/;$(SolutionDir)dependencies/all/stb-image/;$(SolutionDir)dependencies/all/tinyxml2/;$(SolutionDir)dependencies/all/theoraplay/;$(SolutionDir)dependencies/windows/SDL2/include/;$(SolutionDir)dependencies/windows/libogg/include/;$(SolutionDir)dependencies/windows/libvorbis/include/;$(SolutionDir)dependencies/windows/libtheora/include/;$(SolutionDir)dependencies/windows/glew/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(SolutionDir)dependencies/windows/SDL2/lib/$(PlatformTargetAsMSBuildArchitecture)/;$(SolutionDir)dependencies/windows/libvorbis/win32/VS2010/$(Platform)/Debug/;$(SolutionDir)dependencies/windows/libogg/win32/VS2015/$(Platform)/Debug/;$(SolutionDir)dependencies/windows/glew/lib/Release/$(Platform)/</AdditionalLibraryDirectories>
-      <AdditionalDependencies>SDL2.lib;SDL2main.lib;libogg.lib;libvorbis_static.lib;libvorbisfile_static.lib;Opengl32.lib;glu32.lib;glew32.lib;Shell32.lib</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)dependencies/windows/SDL2/lib/$(PlatformTargetAsMSBuildArchitecture)/;$(SolutionDir)dependencies/windows/libvorbis/win32/VS2010/$(Platform)/Debug/;$(SolutionDir)dependencies/windows/libtheora/win32/VS2008/$(Platform)/Debug/;$(SolutionDir)dependencies/windows/libogg/win32/VS2015/$(Platform)/Debug/;$(SolutionDir)dependencies/windows/glew/lib/Release/$(Platform)/</AdditionalLibraryDirectories>
+      <AdditionalDependencies>SDL2.lib;SDL2main.lib;libogg.lib;libvorbis_static.lib;libtheora_static.lib;libvorbisfile_static.lib;Opengl32.lib;glu32.lib;glew32.lib;Shell32.lib</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>copy /Y "$(SolutionDir)dependencies\windows\SDL2\lib\$(PlatformTargetAsMSBuildArchitecture)\SDL2.dll" "$(OutDir)"
@@ -137,15 +137,15 @@ copy /Y "$(SolutionDir)dependencies\windows\glew\bin\Release\$(Platform)\glew32.
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;USE_SW_REN;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)RSDKv4/;$(SolutionDir)RSDKv4/NativeObjects/;$(SolutionDir)dependencies/all/asio/asio/include/;$(SolutionDir)dependencies/all/stb-image/;$(SolutionDir)dependencies/all/tinyxml2/;$(SolutionDir)dependencies/windows/SDL2/include/;$(SolutionDir)dependencies/windows/libogg/include/;$(SolutionDir)dependencies/windows/libvorbis/include/;$(SolutionDir)dependencies/windows/glew/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)RSDKv4/;$(SolutionDir)RSDKv4/NativeObjects/;$(SolutionDir)dependencies/all/asio/asio/include/;$(SolutionDir)dependencies/all/stb-image/;$(SolutionDir)dependencies/all/tinyxml2/;$(SolutionDir)dependencies/all/theoraplay/;$(SolutionDir)dependencies/windows/libtheora/include/;$(SolutionDir)dependencies/windows/SDL2/include/;$(SolutionDir)dependencies/windows/libogg/include/;$(SolutionDir)dependencies/windows/libvorbis/include/;$(SolutionDir)dependencies/windows/glew/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(SolutionDir)dependencies/windows/SDL2/lib/$(PlatformTargetAsMSBuildArchitecture)/;$(SolutionDir)dependencies/windows/libvorbis/win32/VS2010/$(Platform)/Debug/;$(SolutionDir)dependencies/windows/libogg/win32/VS2015/$(Platform)/Debug/;$(SolutionDir)dependencies/windows/glew/lib/Release/$(Platform)/</AdditionalLibraryDirectories>
-      <AdditionalDependencies>SDL2.lib;SDL2main.lib;libogg.lib;libvorbis_static.lib;libvorbisfile_static.lib;Opengl32.lib;glu32.lib;glew32.lib;Shell32.lib</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)dependencies/windows/SDL2/lib/$(PlatformTargetAsMSBuildArchitecture)/;$(SolutionDir)dependencies/windows/libvorbis/win32/VS2010/$(Platform)/Debug/;$(SolutionDir)dependencies/windows/libtheora/win32/VS2008/$(Platform)/Debug/;$(SolutionDir)dependencies/windows/libogg/win32/VS2015/$(Platform)/Debug/;$(SolutionDir)dependencies/windows/glew/lib/Release/$(Platform)/</AdditionalLibraryDirectories>
+      <AdditionalDependencies>SDL2.lib;SDL2main.lib;libogg.lib;libvorbis_static.lib;libtheora_static.lib;libvorbisfile_static.lib;Opengl32.lib;glu32.lib;glew32.lib;Shell32.lib</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>copy /Y "$(SolutionDir)dependencies\windows\SDL2\lib\$(PlatformTargetAsMSBuildArchitecture)\SDL2.dll" "$(OutDir)"
@@ -164,7 +164,7 @@ copy /Y "$(SolutionDir)dependencies\windows\glew\bin\Release\$(Platform)\glew32.
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;USE_SW_REN;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)RSDKv4/;$(SolutionDir)RSDKv4/NativeObjects/;$(SolutionDir)dependencies/all/asio/asio/include/;$(SolutionDir)dependencies/all/stb-image/;$(SolutionDir)dependencies/all/tinyxml2/;$(SolutionDir)dependencies/windows/SDL2/include/;$(SolutionDir)dependencies/windows/libogg/include/;$(SolutionDir)dependencies/windows/libvorbis/include/;$(SolutionDir)dependencies/windows/glew/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)RSDKv4/;$(SolutionDir)RSDKv4/NativeObjects/;$(SolutionDir)dependencies/all/asio/asio/include/;$(SolutionDir)dependencies/all/stb-image/;$(SolutionDir)dependencies/all/tinyxml2/;$(SolutionDir)dependencies/all/theoraplay/;$(SolutionDir)dependencies/windows/libtheora/include/;$(SolutionDir)dependencies/windows/SDL2/include/;$(SolutionDir)dependencies/windows/libogg/include/;$(SolutionDir)dependencies/windows/libvorbis/include/;$(SolutionDir)dependencies/windows/glew/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
@@ -173,8 +173,8 @@ copy /Y "$(SolutionDir)dependencies\windows\glew\bin\Release\$(Platform)\glew32.
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(SolutionDir)dependencies/windows/SDL2/lib/$(PlatformTargetAsMSBuildArchitecture)/;$(SolutionDir)dependencies/windows/libvorbis/win32/VS2010/$(Platform)/Release/;$(SolutionDir)dependencies/windows/libogg/win32/VS2015/$(Platform)/Release/;$(SolutionDir)dependencies/windows/glew/lib/Release/$(Platform)/</AdditionalLibraryDirectories>
-      <AdditionalDependencies>SDL2.lib;SDL2main.lib;libogg.lib;libvorbis_static.lib;libvorbisfile_static.lib;Opengl32.lib;glu32.lib;glew32.lib;Shell32.lib</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)dependencies/windows/SDL2/lib/$(PlatformTargetAsMSBuildArchitecture)/;$(SolutionDir)dependencies/windows/libvorbis/win32/VS2010/$(Platform)/Release/;$(SolutionDir)dependencies/windows/libogg/win32/VS2015/$(Platform)/Release/;$(SolutionDir)dependencies/windows/libtheora/win32/VS2008/$(Platform)/Release/;$(SolutionDir)dependencies/windows/glew/lib/Release/$(Platform)/</AdditionalLibraryDirectories>
+      <AdditionalDependencies>SDL2.lib;SDL2main.lib;libogg.lib;libvorbis_static.lib;libtheora_static.lib;libvorbisfile_static.lib;Opengl32.lib;glu32.lib;glew32.lib;Shell32.lib</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>copy /Y "$(SolutionDir)dependencies\windows\SDL2\lib\$(PlatformTargetAsMSBuildArchitecture)\SDL2.dll" "$(OutDir)"
@@ -193,7 +193,7 @@ copy /Y "$(SolutionDir)dependencies\windows\glew\bin\Release\$(Platform)\glew32.
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;USE_SW_REN;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)RSDKv4/;$(SolutionDir)RSDKv4/NativeObjects/;$(SolutionDir)dependencies/all/asio/asio/include/;$(SolutionDir)dependencies/all/stb-image/;$(SolutionDir)dependencies/all/tinyxml2/;$(SolutionDir)dependencies/windows/SDL2/include/;$(SolutionDir)dependencies/windows/libogg/include/;$(SolutionDir)dependencies/windows/libvorbis/include/;$(SolutionDir)dependencies/windows/glew/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)RSDKv4/;$(SolutionDir)RSDKv4/NativeObjects/;$(SolutionDir)dependencies/all/asio/asio/include/;$(SolutionDir)dependencies/all/stb-image/;$(SolutionDir)dependencies/all/tinyxml2/;$(SolutionDir)dependencies/windows/SDL2/include/;$(SolutionDir)dependencies/windows/libogg/include/;$(SolutionDir)dependencies/windows/libvorbis/include/;$(SolutionDir)dependencies/all/theoraplay/;$(SolutionDir)dependencies/windows/libtheora/include/;$(SolutionDir)dependencies/windows/glew/include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
@@ -202,8 +202,8 @@ copy /Y "$(SolutionDir)dependencies\windows\glew\bin\Release\$(Platform)\glew32.
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(SolutionDir)dependencies/windows/SDL2/lib/$(PlatformTargetAsMSBuildArchitecture)/;$(SolutionDir)dependencies/windows/libvorbis/win32/VS2010/$(Platform)/Release/;$(SolutionDir)dependencies/windows/libogg/win32/VS2015/$(Platform)/Release/;$(SolutionDir)dependencies/windows/glew/lib/Release/$(Platform)/</AdditionalLibraryDirectories>
-      <AdditionalDependencies>SDL2.lib;SDL2main.lib;libogg.lib;libvorbis_static.lib;libvorbisfile_static.lib;Opengl32.lib;glu32.lib;glew32.lib;Shell32.lib</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)dependencies/windows/SDL2/lib/$(PlatformTargetAsMSBuildArchitecture)/;$(SolutionDir)dependencies/windows/libvorbis/win32/VS2010/$(Platform)/Release/;$(SolutionDir)dependencies/windows/libtheora/win32/VS2008/$(Platform)/Release/;$(SolutionDir)dependencies/windows/libogg/win32/VS2015/$(Platform)/Release/;$(SolutionDir)dependencies/windows/glew/lib/Release/$(Platform)/</AdditionalLibraryDirectories>
+      <AdditionalDependencies>SDL2.lib;SDL2main.lib;libogg.lib;libvorbis_static.lib;libtheora_static.lib;libvorbisfile_static.lib;Opengl32.lib;glu32.lib;glew32.lib;Shell32.lib</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>copy /Y "$(SolutionDir)dependencies\windows\SDL2\lib\$(PlatformTargetAsMSBuildArchitecture)\SDL2.dll" "$(OutDir)"
@@ -214,6 +214,7 @@ copy /Y "$(SolutionDir)dependencies\windows\glew\bin\Release\$(Platform)\glew32.
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\dependencies\all\theoraplay\theoraplay.c" />
     <ClCompile Include="..\dependencies\all\tinyxml2\tinyxml2.cpp" />
     <ClCompile Include="Animation.cpp" />
     <ClCompile Include="Audio.cpp" />
@@ -278,8 +279,10 @@ copy /Y "$(SolutionDir)dependencies\windows\glew\bin\Release\$(Platform)\glew32.
     <ClCompile Include="Sprite.cpp" />
     <ClCompile Include="String.cpp" />
     <ClCompile Include="Text.cpp" />
+    <ClCompile Include="Video.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\dependencies\all\theoraplay\theoraplay.h" />
     <ClInclude Include="..\dependencies\all\tinyxml2\tinyxml2.h" />
     <ClInclude Include="Animation.hpp" />
     <ClInclude Include="Audio.hpp" />
@@ -347,6 +350,7 @@ copy /Y "$(SolutionDir)dependencies\windows\glew\bin\Release\$(Platform)\glew32.
     <ClInclude Include="String.hpp" />
     <ClInclude Include="Text.hpp" />
     <ClInclude Include="Userdata.hpp" />
+    <ClInclude Include="Video.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="RSDKv4.rc" />

--- a/RSDKv4/RSDKv4.vcxproj.filters
+++ b/RSDKv4/RSDKv4.vcxproj.filters
@@ -228,6 +228,12 @@
     <ClInclude Include="resource2.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Video.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\dependencies\all\theoraplay\theoraplay.h">
+      <Filter>Header Files\dependencies</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp">
@@ -421,6 +427,12 @@
     </ClCompile>
     <ClCompile Include="NativeObjects\MultiplayerHandler.cpp">
       <Filter>Source Files\nativeEntities</Filter>
+    </ClCompile>
+    <ClCompile Include="Video.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\dependencies\all\theoraplay\theoraplay.c">
+      <Filter>Source Files\dependencies</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/RSDKv4/RetroEngine.cpp
+++ b/RSDKv4/RetroEngine.cpp
@@ -616,6 +616,7 @@ void RetroEngine::Run()
     }
 
     ReleaseAudioDevice();
+    StopVideoPlayback();
     ReleaseRenderDevice();
 #if !RETRO_USE_ORIGINAL_CODE
     ReleaseInputDevices();

--- a/RSDKv4/RetroEngine.hpp
+++ b/RSDKv4/RetroEngine.hpp
@@ -264,6 +264,7 @@ enum RetroStates {
     ENGINE_EXITPAUSE   = 6,
     ENGINE_ENDGAME     = 7,
     ENGINE_RESETGAME   = 8,
+    ENGINE_VIDEOWAIT   = 9,
 
 #if !RETRO_USE_ORIGINAL_CODE && RETRO_USE_NETWORKING
     // Custom GameModes (required to make some features work)
@@ -335,6 +336,7 @@ extern bool engineDebugMode;
 #include "Userdata.hpp"
 #include "Debug.hpp"
 #include "ModAPI.hpp"
+#include "Video.hpp"
 
 // Native Entities
 #include "NativeObjects.hpp"
@@ -486,6 +488,7 @@ public:
 #if RETRO_SOFTWARE_RENDER
     SDL_Texture *screenBuffer   = nullptr;
     SDL_Texture *screenBuffer2x = nullptr;
+    SDL_Texture *videoBuffer = nullptr;
 #endif // RETRO_SOFTWARE_RENDERER
 #endif
 
@@ -501,6 +504,7 @@ public:
 
     SDL_Surface *screenBuffer   = nullptr;
     SDL_Surface *screenBuffer2x = nullptr;
+    SDL_Surface *videoBuffer = nullptr;
 
     SDL_Event sdlEvents;
 #endif // RETRO_USING_SDL1

--- a/RSDKv4/Script.cpp
+++ b/RSDKv4/Script.cpp
@@ -466,6 +466,10 @@ const FunctionInfo functions[] = {
     FunctionInfo("ObjectTileCollision", 4),
     FunctionInfo("ObjectTileGrip", 4),
 
+    // Video
+    FunctionInfo("LoadVideo", 1),
+    FunctionInfo("NextVideoFrame", 0),
+
     // Bitwise Not
     FunctionInfo("Not", 1),
 
@@ -1049,6 +1053,8 @@ enum ScrFunc {
     FUNC_SETSFXATTRIBUTES,
     FUNC_OBJECTTILECOLLISION,
     FUNC_OBJECTTILEGRIP,
+    FUNC_LOADVIDEO,
+    FUNC_NEXTVIDEOFRAME,
     FUNC_NOT,
     FUNC_DRAW3DSCENE,
     FUNC_SETIDENTITYMATRIX,
@@ -4988,6 +4994,22 @@ void ProcessScript(int scriptCodePtr, int jumpTablePtr, byte scriptEvent)
                     case CSIDE_RWALL: ObjectRWallGrip(scriptEng.operands[1], scriptEng.operands[2], scriptEng.operands[3]); break;
                     case CSIDE_ROOF: ObjectRoofGrip(scriptEng.operands[1], scriptEng.operands[2], scriptEng.operands[3]); break;
                 }
+                break;
+            case FUNC_LOADVIDEO:
+                opcodeSize = 0;
+                PauseSound();
+
+                if (FindStringToken(scriptText, ".rsv", 1) <= -1) {
+                    PlayVideoFile(scriptText);
+                } else {
+                    scriptInfo->spriteSheetID = AddGraphicsFile(scriptText);
+                }
+
+                ResumeSound();
+                break;
+            case FUNC_NEXTVIDEOFRAME:
+                opcodeSize = 0;
+                UpdateVideoFrame();
                 break;
             case FUNC_NOT: scriptEng.operands[0] = ~scriptEng.operands[0]; break;
             case FUNC_DRAW3DSCENE:

--- a/RSDKv4/Video.cpp
+++ b/RSDKv4/Video.cpp
@@ -1,0 +1,367 @@
+#include "RetroEngine.hpp"
+
+int currentVideoFrame = 0;
+int videoFrameCount = 0;
+int videoWidth = 0;
+int videoHeight = 0;
+float videoAR = 0;
+
+THEORAPLAY_Decoder *videoDecoder = nullptr;
+const THEORAPLAY_VideoFrame *videoVidData = nullptr;
+THEORAPLAY_Io callbacks;
+
+byte videoSurface = 0;
+int videoFilePos = 0;
+int videoPlaying = 0;
+int vidFrameMS = 0;
+int vidBaseTicks = 0;
+
+bool videoSkipped = false;
+
+static long videoRead(THEORAPLAY_Io *io, void *buf, long buflen)
+{
+    FileIO *file    = (FileIO *)io->userdata;
+    const size_t br = fRead(buf, 1, buflen * sizeof(byte), file);
+    if (br == 0)
+        return -1;
+    return (int)br;
+} // IoFopenRead
+
+static void videoClose(THEORAPLAY_Io *io)
+{
+    FileIO *file = (FileIO *)io->userdata;
+    fClose(file);
+}
+
+void PlayVideoFile(char *filePath) {
+    char pathBuffer[0x100];
+    int len = StrLength(filePath);
+
+    if (StrComp(filePath + ((size_t)len - 2), "us")) {
+        filePath[len - 2] = 0;
+    }
+
+    StrCopy(pathBuffer, "videos/");
+    StrAdd(pathBuffer, filePath);
+    StrAdd(pathBuffer, ".ogv");
+
+    bool addPath = true;
+    // Fixes ".ani" ".Ani" bug and any other case differences
+    char pathLower[0x100];
+    memset(pathLower, 0, sizeof(char) * 0x100);
+    for (int c = 0; c < strlen(pathBuffer); ++c) {
+        pathLower[c] = tolower(pathBuffer[c]);
+    }
+
+#if RETRO_USE_MOD_LOADER
+    for (int m = 0; m < modList.size(); ++m) {
+        if (modList[m].active) {
+            std::map<std::string, std::string>::const_iterator iter = modList[m].fileMap.find(pathLower);
+            if (iter != modList[m].fileMap.cend()) {
+                StrCopy(pathBuffer, iter->second.c_str());
+                Engine.usingDataFile = false;
+                addPath              = false;
+                break;
+            }
+        }
+    }
+#endif
+
+    char filepath[0x100];
+    if (addPath) {
+#if RETRO_PLATFORM == RETRO_UWP
+        static char resourcePath[256] = { 0 };
+
+        if (strlen(resourcePath) == 0) {
+            auto folder = winrt::Windows::Storage::ApplicationData::Current().LocalFolder();
+            auto path   = to_string(folder.Path());
+
+            std::copy(path.begin(), path.end(), resourcePath);
+        }
+
+        sprintf(filepath, "%s/%s", resourcePath, pathBuffer);
+#elif RETRO_PLATFORM == RETRO_OSX || RETRO_PLATFORM == RETRO_ANDROID
+        sprintf(filepath, "%s/%s", gamePath, pathBuffer);
+#else
+        sprintf(filepath, "%s%s", BASE_PATH, pathBuffer);
+#endif
+    }
+    else {
+        sprintf(filepath, "%s", pathBuffer);
+    }
+
+    FileIO *file = fOpen(filepath, "rb");
+    if (file) {
+        PrintLog("Loaded File '%s'!", filepath);
+
+        callbacks.read = videoRead;
+        callbacks.close = videoClose;
+        callbacks.userdata = (void *)file;
+
+        // TODO
+        // perhaps implement multi audio stream support? (e.g. sonic cd cutscenes)
+#if RETRO_USING_SDL2 && !RETRO_USING_OPENGL
+        videoDecoder = THEORAPLAY_startDecode(&callbacks, /*FPS*/ 60, THEORAPLAY_VIDFMT_IYUV);
+#endif
+
+        // TODO: does SDL1.2 support YUV?
+#if RETRO_USING_SDL1 && !RETRO_USING_OPENGL
+        //videoDecoder = THEORAPLAY_startDecode(&callbacks, /*FPS*/ 30, THEORAPLAY_VIDFMT_RGBA, GetGlobalVariableByName("Options.Soundtrack") ? 1 : 0);
+        videoDecoder = THEORAPLAY_startDecodeFile(filepath, 60, THEORAPLAY_VIDFMT_IYUV);
+#endif
+
+#if RETRO_USING_OPENGL
+        //videoDecoder = THEORAPLAY_startDecode(&callbacks, /*FPS*/ 30, THEORAPLAY_VIDFMT_RGBA, GetGlobalVariableByName("Options.Soundtrack") ? 1 : 0);
+        videoDecoder = THEORAPLAY_startDecodeFile(filepath, 60, THEORAPLAY_VIDFMT_RGBA);
+#endif
+
+        videoVidData = NULL;
+
+        if (!videoDecoder) {
+            PrintLog("Video Decoder Error!");
+            return;
+        }
+        while (!videoVidData) {
+            if (!videoVidData)
+                videoVidData = THEORAPLAY_getVideo(videoDecoder);
+        }
+        if (!videoVidData) {
+            PrintLog("Video Error!");
+            return;
+        }
+
+        videoWidth  = videoVidData->width;
+        videoHeight = videoVidData->height;
+        // commit video Aspect Ratio.
+        videoAR = float(videoWidth) / float(videoHeight);
+
+        SetupVideoBuffer(videoWidth, videoHeight);
+        vidBaseTicks = SDL_GetTicks();
+        vidFrameMS   = (videoVidData->fps == 0.0) ? 0 : ((Uint32)(1000.0 / videoVidData->fps));
+        videoPlaying = 1; // playing ogv
+        trackID      = TRACK_COUNT - 1;
+
+        videoSkipped    = false;
+        Engine.gameMode = ENGINE_VIDEOWAIT;
+    }
+    else {
+        PrintLog("Couldn't find file '%s'!", filepath);
+    }
+}
+
+void UpdateVideoFrame() {
+    if (videoPlaying == 2) {
+        if (currentVideoFrame < videoFrameCount) {
+            GFXSurface *surface = &gfxSurface[videoSurface];
+            byte fileBuffer     = 0;
+            ushort fileBuffer2  = 0;
+            FileRead(&fileBuffer, 1);
+            videoFilePos += fileBuffer;
+            FileRead(&fileBuffer, 1);
+            videoFilePos += fileBuffer << 8;
+            FileRead(&fileBuffer, 1);
+            videoFilePos += fileBuffer << 16;
+            FileRead(&fileBuffer, 1);
+            videoFilePos += fileBuffer << 24;
+
+            byte clr[3];
+            for (int i = 0; i < 0x80; ++i) {
+                FileRead(&clr, 3);
+                activePalette32[i].r = clr[0];
+                activePalette32[i].g = clr[1];
+                activePalette32[i].b = clr[2];
+                activePalette[i]     = ((ushort)(clr[0] >> 3) << 11) | 32 * (clr[1] >> 2) | (clr[2] >> 3);
+            }
+
+            FileRead(&fileBuffer, 1);
+            while (fileBuffer != ',') FileRead(&fileBuffer, 1); // gif image start identifier
+
+            FileRead(&fileBuffer2, 2); // IMAGE LEFT
+            FileRead(&fileBuffer2, 2); // IMAGE TOP
+            FileRead(&fileBuffer2, 2); // IMAGE WIDTH
+            FileRead(&fileBuffer2, 2); // IMAGE HEIGHT
+            FileRead(&fileBuffer, 1);  // PaletteType
+            bool interlaced = (fileBuffer & 0x40) >> 6;
+            if (fileBuffer >> 7 == 1) {
+                int c = 0x80;
+                do {
+                    ++c;
+                    FileRead(&fileBuffer, 1);
+                    FileRead(&fileBuffer, 1);
+                    FileRead(&fileBuffer, 1);
+                } while (c != 0x100);
+            }
+            ReadGifPictureData(surface->width, surface->height, interlaced, graphicData, surface->dataPosition);
+
+            SetFilePosition(videoFilePos);
+            ++currentVideoFrame;
+        }
+        else {
+            videoPlaying = 0;
+            CloseFile();
+        }
+    }
+}
+int count;
+int ProcessVideo() {
+    if (videoPlaying == 1) {
+        CheckKeyPress(&inputPress);
+
+        if (videoSkipped && fadeMode < 0xFF) {
+            fadeMode += 8;
+        }
+
+        // taxman forgot the anyPress i guess
+        if (inputDevice[INPUT_BUTTONA].press || inputDevice[INPUT_BUTTONB].press || inputDevice[INPUT_BUTTONC].press || inputDevice[INPUT_BUTTONX].press || inputDevice[INPUT_BUTTONY].press || inputDevice[INPUT_BUTTONZ].press || inputDevice[INPUT_BUTTONL].press || inputDevice[INPUT_BUTTONR].press || inputDevice[INPUT_START].press || inputDevice[INPUT_SELECT].press || touches > 0) {
+            if (!videoSkipped)
+                fadeMode = 0;
+
+            videoSkipped = true;
+        }
+
+        // ok so
+        // theoraplay is just never returning false for some reason???
+        // i hacked around this i guess, check line 237
+        if (/*!THEORAPLAY_isDecoding(videoDecoder) || */(videoSkipped && fadeMode >= 0xFF)) {
+            StopVideoPlayback();
+            ResumeSound();
+            return 1; // video finished
+        }
+
+        // Don't pause or it'll go wild
+        if (videoPlaying == 1) {
+            const Uint32 now = (SDL_GetTicks() - vidBaseTicks);
+
+            if (!videoVidData) {
+                videoVidData = THEORAPLAY_getVideo(videoDecoder);
+                // we done lmao
+                if (!videoVidData) {
+                    StopVideoPlayback();
+                    ResumeSound();
+                    return 1;
+                }
+            }
+
+            // Play video frames when it's time.
+            if (videoVidData && (videoVidData->playms <= now)) {
+                if (vidFrameMS && ((now - videoVidData->playms) >= vidFrameMS)) {
+                    // Skip frames to catch up, but keep track of the last one+
+                    //  in case we catch up to a series of dupe frames, which
+                    //  means we'd have to draw that final frame and then wait for
+                    //  more.
+
+                    const THEORAPLAY_VideoFrame *last = videoVidData;
+                    while ((videoVidData = THEORAPLAY_getVideo(videoDecoder)) != NULL) {
+                        THEORAPLAY_freeVideo(last);
+                        last = videoVidData;
+                        if ((now - videoVidData->playms) < vidFrameMS)
+                            break;
+                    }
+
+                    if (!videoVidData) {
+                        videoVidData = last;
+                    }
+                }
+
+                // do nothing; we're far behind and out of options.
+                if (!videoVidData) {
+                    // video lagging uh oh
+                }
+
+#if RETRO_USING_OPENGL
+                glBindTexture(GL_TEXTURE_2D, videoBuffer);
+                glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, videoVidData->width, videoVidData->height, GL_RGBA, GL_UNSIGNED_BYTE, videoVidData->pixels);
+                glBindTexture(GL_TEXTURE_2D, 0);
+#elif RETRO_USING_SDL2
+                int half_w     = videoVidData->width / 2;
+                const Uint8 *y = (const Uint8 *)videoVidData->pixels;
+                const Uint8 *u = y + (videoVidData->width * videoVidData->height);
+                const Uint8 *v = u + (half_w * (videoVidData->height / 2));
+
+                SDL_UpdateYUVTexture(Engine.videoBuffer, NULL, y, videoVidData->width, u, half_w, v, half_w);
+#elif RETRO_USING_SDL1
+                memcpy(Engine.videoBuffer->pixels, videoVidData->pixels, videoVidData->width * videoVidData->height * sizeof(uint));
+#endif
+                THEORAPLAY_freeVideo(videoVidData);
+                videoVidData = NULL;
+            }
+
+            return 2; // its playing as expected
+        }
+    }
+
+    return 0; // its not even initialised
+}
+
+void StopVideoPlayback()
+{
+    if (videoPlaying == 1) {
+        // `videoPlaying` and `videoDecoder` are read by
+        // the audio thread, so lock it to prevent a race
+        // condition that results in invalid memory accesses.
+        SDL_LockAudio();
+
+        if (videoSkipped && fadeMode >= 0xFF)
+            fadeMode = 0;
+
+        if (videoVidData) {
+            THEORAPLAY_freeVideo(videoVidData);
+            videoVidData = NULL;
+        }
+        if (videoDecoder) {
+            THEORAPLAY_stopDecode(videoDecoder);
+            videoDecoder = NULL;
+        }
+
+        CloseVideoBuffer();
+        videoPlaying = 0;
+
+        SDL_UnlockAudio();
+    }
+}
+
+void SetupVideoBuffer(int w, int h) {
+    #if RETRO_USING_OPENGL
+    if (videoBuffer > 0) {
+        glDeleteTextures(1, &videoBuffer);
+        videoBuffer = 0;
+    }
+    glGenTextures(1, &videoBuffer);
+    glBindTexture(GL_TEXTURE_2D, videoBuffer);
+
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+    glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, videoVidData->width, videoVidData->height, GL_RGBA, GL_UNSIGNED_BYTE, videoVidData->pixels);
+
+    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glBindTexture(GL_TEXTURE_2D, 0);
+#elif RETRO_USING_SDL1
+    Engine.videoBuffer = SDL_CreateRGBSurface(0, width, height, 32, 0x000000FF, 0x0000FF00, 0x00FF0000, 0xFF000000);
+
+    if (!Engine.videoBuffer)
+        PrintLog("Failed to create video buffer!");
+#elif RETRO_USING_SDL2
+    Engine.videoBuffer = SDL_CreateTexture(Engine.renderer, SDL_PIXELFORMAT_YV12, SDL_TEXTUREACCESS_TARGET, w, h);
+
+    if (!Engine.videoBuffer)
+        PrintLog("Failed to create video buffer!");
+#endif
+}
+void CloseVideoBuffer() {
+    if (videoPlaying == 1) {
+#if RETRO_USING_OPENGL
+        if (videoBuffer > 0) {
+            glDeleteTextures(1, &videoBuffer);
+            videoBuffer = 0;
+        }
+#elif RETRO_USING_SDL1
+        SDL_FreeSurface(Engine.videoBuffer);
+        Engine.videoBuffer = nullptr;
+#elif RETRO_USING_SDL2
+        SDL_DestroyTexture(Engine.videoBuffer);
+        Engine.videoBuffer = nullptr;
+#endif
+    }
+}

--- a/RSDKv4/Video.hpp
+++ b/RSDKv4/Video.hpp
@@ -1,0 +1,31 @@
+#ifndef VIDEO_HPP
+#define VIDEO_HPP
+
+#include "theoraplay.h"
+
+extern int currentVideoFrame;
+extern int videoFrameCount;
+extern int videoWidth;
+extern int videoHeight;
+extern float videoAR;
+
+extern THEORAPLAY_Decoder *videoDecoder;
+extern const THEORAPLAY_VideoFrame *videoVidData;
+extern const THEORAPLAY_AudioPacket *videoAudioData;
+extern THEORAPLAY_Io callbacks;
+
+extern byte videoSurface;
+extern int videoFilePos;
+extern int videoPlaying; // 0 = not playing, 1 = playing ogv, 2 = playing rsv
+extern int vidFrameMS;
+extern int vidBaseTicks;
+
+void PlayVideoFile(char *filePath);
+void UpdateVideoFrame();
+int ProcessVideo();
+void StopVideoPlayback();
+
+void SetupVideoBuffer(int w, int h);
+void CloseVideoBuffer();
+
+#endif

--- a/dependencies/windows/dependencies.txt
+++ b/dependencies/windows/dependencies.txt
@@ -10,4 +10,8 @@ download libogg and unzip it in "./libogg/", then build the static library
 libvorbis: https://xiph.org/downloads/ (libvorbis)
 download libvorbis and unzip it in "./libvorbis/", then build the VS2010 static library (win32/VS2010/vorbis_static.sln)
 
+libtheora: https://xiph.org/downloads/ (libtheora)
+download libtheora and unzip it in "./libtheora/", then build the VS2008 static library (win32/VS2008/libtheora_static.sln)
+ignore any building errors you may get, you should at least build the library itself which is all you need
+
 glew: http://glew.sourceforge.net/ download binaries, place the unzipped folder into "./" and rename it to "glew"


### PR DESCRIPTION
This commit adds video player support. This ports 2 script functions from RSDKv3 (`LoadVideo` and `NextVideoFrame`). This commit has been tested on Linux and Windows.

- The video player doesn't support swapping audio streams (e.g. RSDKv3 Sonic CD cutscenes)
- Neither has it been tested with RSV files (e.g. Sonic Nexus cutscenes)

This commit adds 2 additional dependencies, `libtheora` and `theoraplay` (pulled via submodules).