### PR TITLE
Force case sensitivity for Linux systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,14 +113,13 @@ SOURCES = \
     RSDKv4/Userdata     \
     RSDKv4/Video        \
     RSDKv4/main         \
+    RSDKv4/fcaseopen    \
     RSDKv4/NativeObjects/All                \
     dependencies/all/theoraplay/theoraplay  \
     dependencies/all/tinyxml2/tinyxml2
-	
-ifneq ($(FORCE_CASE_INSENSITIVE),)
-	CXXFLAGS_ALL += -DFORCE_CASE_INSENSITIVE
-	SOURCES += RSDKv4/fcaseopen
-endif
+
+CXXFLAGS_ALL += -DFORCE_CASE_INSENSITIVE
+
 
 PKGSUFFIX ?= $(SUFFIX)
 

--- a/Makefile
+++ b/Makefile
@@ -113,13 +113,14 @@ SOURCES = \
     RSDKv4/Userdata     \
     RSDKv4/Video        \
     RSDKv4/main         \
-    RSDKv4/fcaseopen    \
     RSDKv4/NativeObjects/All                \
     dependencies/all/theoraplay/theoraplay  \
     dependencies/all/tinyxml2/tinyxml2
-
-CXXFLAGS_ALL += -DFORCE_CASE_INSENSITIVE
-
+	
+ifneq ($(FORCE_CASE_INSENSITIVE),)
+	CXXFLAGS_ALL += -DFORCE_CASE_INSENSITIVE
+	SOURCES += RSDKv4/fcaseopen
+endif
 
 PKGSUFFIX ?= $(SUFFIX)
 

--- a/Makefile
+++ b/Makefile
@@ -113,13 +113,13 @@ SOURCES = \
     RSDKv4/Userdata     \
     RSDKv4/Video        \
     RSDKv4/main         \
+    RSDKv4/fcaseopen    \
     RSDKv4/NativeObjects/All                \
     dependencies/all/theoraplay/theoraplay  \
     dependencies/all/tinyxml2/tinyxml2
 	
 ifneq ($(FORCE_CASE_INSENSITIVE),)
 	CXXFLAGS_ALL += -DFORCE_CASE_INSENSITIVE
-	SOURCES += RSDKv4/fcaseopen
 endif
 
 PKGSUFFIX ?= $(SUFFIX)

--- a/RSDKv4/Reader.hpp
+++ b/RSDKv4/Reader.hpp
@@ -1,6 +1,19 @@
 #ifndef READER_H
 #define READER_H
 
+#if RETRO_PLATFORM == RETRO_LINUX   // Force case insensitivity for Linux
+
+#include "fcaseopen.h"
+#define FileIO                                          FILE
+#define fOpen(path, mode)                               fcaseopen(path, mode)
+#define fRead(buffer, elementSize, elementCount, file)  fread(buffer, elementSize, elementCount, file)
+#define fSeek(file, offset, whence)                     fseek(file, offset, whence)
+#define fTell(file)                                     ftell(file)
+#define fClose(file)                                    fclose(file)
+#define fWrite(buffer, elementSize, elementCount, file) fwrite(buffer, elementSize, elementCount, file)
+
+#else                               // Force case insensitivity for Linux
+
 #ifdef FORCE_CASE_INSENSITIVE
 
 #include "fcaseopen.h"
@@ -31,6 +44,8 @@
 #define fClose(file)                                    fclose(file)
 #define fWrite(buffer, elementSize, elementCount, file) fwrite(buffer, elementSize, elementCount, file)
 #endif
+
+#endif                              // Force case insensitivity for Linux
 
 #endif
 


### PR DESCRIPTION
The Makefile compiles with fcaseopen.c, ignoring build flags
Reader.hpp uses fcaseopen.h even if SDL is present (for Linux systems only)